### PR TITLE
Fixes for Paint View / X-Ray View switching anomalies

### DIFF
--- a/SidebarGUIPlugin.py
+++ b/SidebarGUIPlugin.py
@@ -32,7 +32,8 @@ class SidebarGUIPlugin(Extension):
         preferences.addPreference("sidebargui/settings_window_left", 65535)
         preferences.addPreference("sidebargui/settings_window_top", 65535)
         preferences.addPreference("sidebargui/settings_window_height", 0)
-
+        preferences.addPreference("sidebargui/paint_tool_active", False)
+        
         self._controller = Application.getInstance().getController()
         self._controller.activeStageChanged.connect(self._onStageChanged)
         self._controller.activeViewChanged.connect(self._onViewChanged)
@@ -90,10 +91,6 @@ class SidebarGUIPlugin(Extension):
         active_stage_id = self._controller.getActiveStage().getPluginId()
         active_view = self._controller.getActiveView()
 
-        # Don't change view if PaintTool is active
-        if active_view and active_view.getPluginId() == "PaintTool":
-            return
-
         view_id = ""
 
         if active_stage_id == "PrepareStage":
@@ -116,10 +113,6 @@ class SidebarGUIPlugin(Extension):
 
         active_stage_id = active_stage.getPluginId()
         active_view_id = active_view.getPluginId()
-
-        # Force machine settings update when PaintTool is activated to fix rendering issue
-        if active_view_id == "PaintTool":
-            QTimer.singleShot(0, lambda: Application.getInstance().getMachineManager().forceUpdateAllSettings())
 
         if (
             active_stage_id == "SmartSlicePlugin"

--- a/resources/qml/PrepareStageLegend40.qml
+++ b/resources/qml/PrepareStageLegend40.qml
@@ -67,26 +67,44 @@ Cura.ExpandableComponent
             id: xrayViewCheckBox
             checked: parent.activeView == "XRayView"
             visible: !externalViewLabel.visible
+						
             onClicked:
             {
-                if(checked && parent.activeView != "XRayView")
+								var prepareMode = String(UM.Controller.activeView ?? "").substr(0, String(UM.Controller.activeView ?? "").indexOf("("))
+							
+                if (checked && parent.activeView != "XRayView")
                 {
+										if (prepareMode === "PaintView")
+										{							
+												UM.Preferences.setValue("sidebargui/paint_tool_active", true)
+										}
+										else
+										{							
+												UM.Preferences.setValue("sidebargui/paint_tool_active", false)
+										}
+											
                     SidebarGUIPlugin.setActiveView("XRayView")
                 }
-                else if(! checked && parent.activeView != "SolidView")
+                else if (! checked && parent.activeView != "SolidView")
                 {
                     SidebarGUIPlugin.setActiveView("SolidView")
+
+										if (UM.Preferences.getValue("sidebargui/paint_tool_active"))
+										{
+												SidebarGUIPlugin.setActiveView("PaintTool")
+										}
                 }
             }
-            text: catalog.i18nc("@label", "X-Ray view")
+            text: catalog.i18nc("@label", "X-Ray View")
             width: parent.width
         }
 
         Label
         {
             id: externalViewLabel
-
-            height: UM.Theme.getSize("layerview_row").height
+						
+						horizontalAlignment: Text.AlignHCenter
+						height: UM.Theme.getSize("layerview_row").height
             width: parent.width
             color: UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default")
@@ -109,6 +127,7 @@ Cura.ExpandableComponent
             color: UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default")
             renderType: Text.NativeRendering
+						
             Rectangle
             {
                 anchors.verticalCenter: parent.verticalCenter
@@ -126,7 +145,7 @@ Cura.ExpandableComponent
 
         Label
         {
-            text: catalog.i18nc("@label", "Outside buildvolume")
+            text: catalog.i18nc("@label", "Outside Build Volume")
             visible: parent.activeView == "SolidView"
 
             height: UM.Theme.getSize("layerview_row").height
@@ -134,6 +153,7 @@ Cura.ExpandableComponent
             color: UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default")
             renderType: Text.NativeRendering
+						
             Rectangle
             {
                 anchors.verticalCenter: parent.verticalCenter
@@ -162,7 +182,20 @@ Cura.ExpandableComponent
 
         Label
         {
-            text: catalog.i18nc("@label", "Normal geometry")
+            text: catalog.i18nc("@label", "Paint Tool")
+            visible: parent.activeView == "PaintView"
+
+						horizontalAlignment: Text.AlignHCenter
+            height: UM.Theme.getSize("layerview_row").height
+            width: parent.width
+            color: UM.Theme.getColor("setting_control_text")
+            font: UM.Theme.getFont("default")
+            renderType: Text.NativeRendering					
+        }
+
+        Label
+        {
+            text: catalog.i18nc("@label", "Normal Geometry")
             visible: parent.activeView == "XRayView"
 
             height: UM.Theme.getSize("layerview_row").height
@@ -170,6 +203,7 @@ Cura.ExpandableComponent
             color: UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default")
             renderType: Text.NativeRendering
+
             Rectangle
             {
                 anchors.verticalCenter: parent.verticalCenter
@@ -198,7 +232,7 @@ Cura.ExpandableComponent
 
         Label
         {
-            text: catalog.i18nc("@label", "Geometry error")
+            text: catalog.i18nc("@label", "Geometry Error")
             visible: parent.activeView == "XRayView"
 
             height: UM.Theme.getSize("layerview_row").height
@@ -206,6 +240,7 @@ Cura.ExpandableComponent
             color: UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default")
             renderType: Text.NativeRendering
+
             Rectangle
             {
                 anchors.verticalCenter: parent.verticalCenter

--- a/resources/qml/PrepareStageLegend50.qml
+++ b/resources/qml/PrepareStageLegend50.qml
@@ -66,26 +66,44 @@ Cura.ExpandableComponent
             id: xrayViewCheckBox
             checked: parent.activeView == "XRayView"
             visible: !externalViewLabel.visible
+						
             onClicked:
             {
-                if(checked && parent.activeView != "XRayView")
+								var prepareMode = String(UM.Controller.activeView ?? "").substr(0, String(UM.Controller.activeView ?? "").indexOf("("))
+							
+                if (checked && parent.activeView != "XRayView")
                 {
+										if (prepareMode === "PaintView")
+										{							
+												UM.Preferences.setValue("sidebargui/paint_tool_active", true)
+										}
+										else
+										{							
+												UM.Preferences.setValue("sidebargui/paint_tool_active", false)
+										}
+											
                     SidebarGUIPlugin.setActiveView("XRayView")
                 }
-                else if(! checked && parent.activeView != "SolidView")
+                else if (! checked && parent.activeView != "SolidView")
                 {
                     SidebarGUIPlugin.setActiveView("SolidView")
+
+										if (UM.Preferences.getValue("sidebargui/paint_tool_active"))
+										{
+												SidebarGUIPlugin.setActiveView("PaintTool")
+										}
                 }
             }
-            text: catalog.i18nc("@label", "X-Ray view")
+            text: catalog.i18nc("@label", "X-Ray View")
             width: parent.width
         }
 
         UM.Label
         {
             id: externalViewLabel
-
-            height: UM.Theme.getSize("layerview_row").height
+						
+						horizontalAlignment: Text.AlignHCenter
+						height: UM.Theme.getSize("layerview_row").height
             width: parent.width
             color: UM.Theme.getColor("setting_control_text")
         }
@@ -104,7 +122,7 @@ Cura.ExpandableComponent
             height: UM.Theme.getSize("layerview_row").height
             width: parent.width
             color: UM.Theme.getColor("setting_control_text")
-
+						
             Rectangle
             {
                 anchors.verticalCenter: parent.verticalCenter
@@ -122,13 +140,13 @@ Cura.ExpandableComponent
 
         UM.Label
         {
-            text: catalog.i18nc("@label", "Outside buildvolume")
+            text: catalog.i18nc("@label", "Outside Build Volume")
             visible: parent.activeView == "SolidView"
 
             height: UM.Theme.getSize("layerview_row").height
             width: parent.width
             color: UM.Theme.getColor("setting_control_text")
-
+						
             Rectangle
             {
                 id: outsideBuildVolumeSwatch
@@ -158,7 +176,18 @@ Cura.ExpandableComponent
 
         UM.Label
         {
-            text: catalog.i18nc("@label", "Normal geometry")
+            text: catalog.i18nc("@label", "Paint Tool")
+            visible: parent.activeView == "PaintView"
+
+						horizontalAlignment: Text.AlignHCenter
+            height: UM.Theme.getSize("layerview_row").height
+            width: parent.width
+            color: UM.Theme.getColor("setting_control_text")
+        }
+
+        UM.Label
+        {
+            text: catalog.i18nc("@label", "Normal Geometry")
             visible: parent.activeView == "XRayView"
 
             height: UM.Theme.getSize("layerview_row").height
@@ -186,7 +215,7 @@ Cura.ExpandableComponent
 
         UM.Label
         {
-            text: catalog.i18nc("@label", "Geometry error")
+            text: catalog.i18nc("@label", "Geometry Error")
             visible: parent.activeView == "XRayView"
 
             height: UM.Theme.getSize("layerview_row").height


### PR DESCRIPTION
This PR fixes the following legend & view mode anomalies when switching between the Paint Tool & X-Ray View.

1. If the Paint Tool is active & X-Ray View is selected then the interface now returns to the Paint View when X-Ray View is deselected rather than the Solid View even though the Paint Tool panel remained open.

2. If the Paint Tool is active & X-Ray View is selected then the X-Ray View Legend is now displayed rather than disappearing. The disappearing legend persisted in both X-Ray View & Solid View even if the Paint Tool was subsequently exited. The only way I found to display it again was to toggle to Preview & back to Prepare again, which seemed to force a refresh of the code for displaying the legend

3. When the Paint Tool is active the legend now displays 'Paint Tool' rather than the legend colours for the Solid View, which it would otherwise do after resolving 2 above. The Paint Tool colours are pretty much self explanatory in the plugin panel anyhow & I didn't think there was a reason to include them in the legend too

4. Removed some Paint Tool switching code that was causing delays activating the Paint tool, which didn't deem to have a function or affect operation when removed

5.  Correct case of text in Solid View / X-Ray View Legend

This is my first attempt at creating a PR so hopefully I've followed the correct process